### PR TITLE
Add requirements.txt to enable easy installation of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+dash
+dash_core_components
+dash_html_components
+fiona
+flask
+mapboxgl
+measure
+gdal
+pandas
+pandas
+plotly
+psycopg2
+pyproj
+requests
+shapely
+sortedcontainers
+sqlalchemy


### PR DESCRIPTION
I went through all the files and tried to pick out all the dependencies outside of the standard library.  It should be possible now to get started using `pip install -r requirements.txt` from the root directory.