### PR TITLE
Add generated data to the gitignore

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -102,3 +102,9 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Generated data
+bat_trips
+lemon_trips
+bat_status_change
+lemon_status_change


### PR DESCRIPTION
The results of the `data/generate_data.py` script are not ignored by git.  If these results aren't intended to be checked in to the repo, they should be included in the `.gitignore`.